### PR TITLE
feat: make PDF processor language-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@
 
 ## Overview
 
-This tool extracts transaction data from Trade Republic PDF statements and converts them to CSV format for easier analysis and integration with personal finance tools. It processes Italian Trade Republic statements and handles both cash transactions and trading activities.
+This tool extracts transaction data from Trade Republic PDF statements and converts them to CSV format for easier analysis and integration with personal finance tools. It supports multiple languages through configuration and handles both cash transactions and trading activities.
 
 ### Key Features
 
 - **PDF Processing**: Extracts data from Trade Republic PDF statements using OCR and table detection
+- **Language Support**: Configurable for any language through settings
 - **Dual CSV Output**: Generates 2 CSV files - transactions (cards, transfers, fees, cashback) and trades (buy/sell)
 - **Visual Debugging**: Optional grid overlay to visualize extraction areas
 - **Multi-row Cell Handling**: Automatically combines split table cells
@@ -33,7 +34,7 @@ This tool extracts transaction data from Trade Republic PDF statements and conve
 
 This is a **personal project** built specifically for my own finance tracking needs. I created this tool because I needed to extract and process my Trade Republic transaction data for personal accounting purposes.
 
-**Language Limitation:** This tool has been tested **only with Italian Trade Republic account statements**. Since I don't have access to statements in other languages, I cannot guarantee functionality with non-Italian Trade Republic accounts. However, the script can potentially be adapted for other languages through manual configuration of headers, valid transaction types, and extraction areas (requires technical knowledge and testing).
+**Language Support:** This tool is now **language-agnostic** and supports any Trade Republic language through configuration. The tool uses configurable settings that allow adaptation for any Trade Republic language by updating column names, transaction types, and header mappings in the settings.json file.
 
 **PDF Structure Dependency:** This script is hardcoded for the current Trade Republic PDF format. **If Trade Republic updates their PDF structure, this tool may stop working or produce incorrect results.** If this happens, please contact me at [info@gianlucaiavicoli.dev](mailto:info@gianlucaiavicoli.dev) and I'll investigate updating the extraction logic.
 
@@ -164,9 +165,12 @@ All settings are configured in `settings.json`. Here's a complete breakdown of e
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `columns` | array | `["DATA", "TIPO", ...]` | Expected column headers in Italian |
-| `valid_types` | array | Transaction types to extract | Only process rows with these TIPO values |
+| `columns` | array | `["DATA", "TIPO", ...]` | Expected column headers in your language |
+| `valid_types` | array | Transaction types to extract | Only process rows with these transaction type values |
 | `header_alignment_map` | object | Column alignment settings | Controls text extraction alignment for each column |
+| `anchor_column` | string | `"TIPO"` | Column used for header detection |
+| `trade_type_name` | string | `"Commercio"` | Transaction type that identifies trades |
+| `column_mappings` | object | Maps logical names to actual columns | Language-independent column references |
 
 ### Extraction Areas (Pixel Coordinates)
 
@@ -183,13 +187,27 @@ All settings are configured in `settings.json`. Here's a complete breakdown of e
 }
 ```
 
-### Valid Transaction Types
+### Language Configuration Example
 
-The tool processes these Italian transaction types:
-- `"Transazione con carta"` - Card transactions
-- `"Bonifico SEPA istantaneo"` - SEPA instant transfers  
-- `"Commercio"` - Trading activities (buy/sell)
-- `"Commissione"` - Fees and commissions
+**Italian Configuration:**
+```json
+{
+  "columns": ["DATA", "TIPO", "DESCRIZIONE", "IN ENTRATA", "IN USCITA", "SALDO"],
+  "valid_types": ["Transazione con carta", "Bonifico SEPA istantaneo", "Commercio", "Commissione"],
+  "anchor_column": "TIPO",
+  "trade_type_name": "Commercio",
+  "column_mappings": {
+    "date": "DATA",
+    "type": "TIPO",
+    "description": "DESCRIZIONE",
+    "money_in": "IN ENTRATA",
+    "money_out": "IN USCITA",
+    "balance": "SALDO"
+  }
+}
+```
+
+For other languages, adapt the column names and transaction types to match your PDF's language.
 
 ## How It Works
 

--- a/main.py
+++ b/main.py
@@ -41,8 +41,10 @@ def header_xcoords_in_bbox(
     page: pdfplumber.page.Page,
     bbox: Tuple[float, float, float, float],
     headers: Dict[str, str],
-    anchor: str = "TIPO",
+    anchor: str = None,
 ) -> Dict[str, float]:
+    if anchor is None:
+        anchor = S.get("anchor_column", "TIPO")
 
     sub   = page.crop(bbox)
     raw   = sub.extract_words(x_tolerance=1, y_tolerance=2, keep_blank_chars=True)
@@ -188,17 +190,22 @@ def combine_multirow_cells(df: pd.DataFrame) -> pd.DataFrame:
     return out
 
 
-def tidy_money_cols(df: pd.DataFrame, cols: List[str]) -> pd.DataFrame:
-    """Remove currency symbol and thousand separators, keep NaN."""
-    for c in cols:
-        df[c] = df[c].apply(
-            lambda v: v if pd.isna(v) else v.replace(S['currency_symbol'], "").replace(".", "").strip()
-        )
+def tidy_money_cols(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove currency symbol and thousand separators from money columns, keep NaN."""
+    cm = S["column_mappings"]
+    money_cols = [cm["money_in"], cm["money_out"], cm["balance"]]
+
+    for c in money_cols:
+        if c in df.columns:
+            df[c] = df[c].apply(
+                lambda v: v if pd.isna(v) else v.replace(S['currency_symbol'], "").replace(".", "").strip()
+            )
     return df
 
 def validate_types(df: pd.DataFrame, valid_types: List[str]) -> pd.DataFrame:
-    """Keep only rows whose 'TIPO' value is in `valid_types`."""
-    mask = df["TIPO"].isin(valid_types)
+    """Keep only rows whose type column value is in `valid_types`."""
+    type_col = S["column_mappings"]["type"]
+    mask = df[type_col].isin(valid_types)
 
     return df.loc[mask].copy()
 
@@ -228,6 +235,11 @@ def setup():
     if not Path(OUTPUT_DIR).exists(): Path.mkdir(OUTPUT_DIR)
 
 def parse_trades(trades: pd.DataFrame) -> pd.DataFrame:
+    # Get column names from settings
+    cm = S["column_mappings"]
+    desc_col = cm["description"]
+    out_col = cm["money_out"]
+
     pattern = re.compile(
         r'''(?ix)
         ^\s*
@@ -243,8 +255,8 @@ def parse_trades(trades: pd.DataFrame) -> pd.DataFrame:
         ,\s*quantity:\s*
         (?P<qty>[0-9.,]+)
         ''')
-    
-    parsed = trades['DESCRIZIONE'].str.extract(pattern)
+
+    parsed = trades[desc_col].str.extract(pattern)
 
     parsed['TRADE_TYPE'] = (
         parsed['trade_type']
@@ -263,10 +275,13 @@ def parse_trades(trades: pd.DataFrame) -> pd.DataFrame:
 
     trades['PRICE'] = None
     trades['FEE'] = None
-    trades['AMOUNT'] = trades['IN USCITA']
+    trades['AMOUNT'] = trades[out_col]
     trades['QUANTITY'] = trades['QUANTITY'].str.replace(".", ",")
 
-    return trades[['DATA', 'NAME', 'ISIN', 'TRADE_TYPE', 'QUANTITY', 'FEE', 'AMOUNT', 'PRICE']]
+    # Use configured date column name
+    date_col = cm["date"]
+
+    return trades[[date_col, 'NAME', 'ISIN', 'TRADE_TYPE', 'QUANTITY', 'FEE', 'AMOUNT', 'PRICE']]
 
 
 def get_trade_republic_data(tr_file) -> list[pd.DataFrame]:
@@ -289,24 +304,33 @@ def get_trade_republic_data(tr_file) -> list[pd.DataFrame]:
                 area_px = S["area_default"]
 
             bbox_pts = px_area_to_pts(area_px, page.width, page.height)
-            hdr_x    = header_xcoords_in_bbox(page, bbox_pts, S["header_alignment_map"])
+            hdr_x    = header_xcoords_in_bbox(page, bbox_pts, S["header_alignment_map"], S.get("anchor_column"))
             
             if not hdr_x:
                 hdr_x = header_xcoords_in_bbox(
                     page,
                     (0, 0, page.width, page.height),
-                    S["header_alignment_map"]
+                    S["header_alignment_map"],
+                    S.get("anchor_column")
                 )
 
             if not hdr_x:
                 break
 
+            # Use column mappings to get the actual column names
+            cm = S["column_mappings"]
+            type_col = cm["type"]
+            desc_col = cm["description"]
+            in_col = cm["money_in"]
+            out_col = cm["money_out"]
+            balance_col = cm["balance"]
+
             x_pts = sorted([
-                hdr_x["TIPO"] - 2,
-                hdr_x["DESCRIZIONE"] - 2,
-                hdr_x["IN ENTRATA"] - 2,
-                hdr_x["IN USCITA"] - 2,
-                ((hdr_x["IN USCITA"] + hdr_x["SALDO"]) / 2) - 4
+                hdr_x[type_col] - 2,
+                hdr_x[desc_col] - 2,
+                hdr_x[in_col] - 2,
+                hdr_x[out_col] - 2,
+                ((hdr_x[out_col] + hdr_x[balance_col]) / 2) - 4
             ])
 
             if S['show_preview'] and all_page_images:
@@ -348,10 +372,15 @@ def get_trade_republic_data(tr_file) -> list[pd.DataFrame]:
     raw = raw.drop([0]).reset_index(drop=True)
 
     merged = combine_multirow_cells(raw)
-    merged = tidy_money_cols(merged, ["IN ENTRATA", "IN USCITA", "SALDO"])
+    merged = tidy_money_cols(merged)
     merged = validate_types(merged, S["valid_types"])
-    trades = merged[merged['TIPO'] == 'Commercio'].copy()
-    transactions = merged[merged['TIPO'] != 'Commercio'].copy()
+
+    # Use configured trade type name
+    type_col = S["column_mappings"]["type"]
+    trade_type = S.get("trade_type_name", "Commercio")
+
+    trades = merged[merged[type_col] == trade_type].copy()
+    transactions = merged[merged[type_col] != trade_type].copy()
 
     trades = parse_trades(trades)
     trades.reset_index(drop=True, inplace=True)

--- a/settings.example.json
+++ b/settings.example.json
@@ -7,7 +7,7 @@
   "resize_px": [595, 841.88],
   "columns": [
     "DATA",
-    "TIPO", 
+    "TIPO",
     "DESCRIZIONE",
     "IN ENTRATA",
     "IN USCITA",
@@ -15,18 +15,28 @@
   ],
   "valid_types": [
     "Transazione con carta",
-    "Bonifico SEPA istantaneo", 
+    "Bonifico SEPA istantaneo",
     "Commercio",
     "Commissione"
   ],
   "header_alignment_map": {
     "DATA": "left",
-    "TIPO": "left", 
+    "TIPO": "left",
     "DESCRIZIONE": "left",
     "IN ENTRATA": "left",
     "IN USCITA": "left",
     "SALDO": "right"
   },
   "area_first": [343, 42, 770, 552],
-  "area_default": [55, 42, 770, 552]
+  "area_default": [55, 42, 770, 552],
+  "anchor_column": "TIPO",
+  "trade_type_name": "Commercio",
+  "column_mappings": {
+    "date": "DATA",
+    "type": "TIPO",
+    "description": "DESCRIZIONE",
+    "money_in": "IN ENTRATA",
+    "money_out": "IN USCITA",
+    "balance": "SALDO"
+  }
 }


### PR DESCRIPTION
Summary
  - Replace hardcoded Italian headers with configurable mappings
  - Add language-agnostic configuration fields
  - Fixes hardcoded column names that caused "No objects to concatenate" error

  Fixes #1
  Fixes #3 